### PR TITLE
Report stage properties

### DIFF
--- a/lib/src/main/scala/com/joom/spark/monitoring/Parts.scala
+++ b/lib/src/main/scala/com/joom/spark/monitoring/Parts.scala
@@ -36,6 +36,7 @@ case class StageSummary(
                          inputGB: Double,
                          shuffleWriteGB: Double,
                          peakExecutionMemoryGB: Double,
+                         properties: Map[String, String],
                        )
 
 case class ExecutorMetric(


### PR DESCRIPTION
In some cases (e.g. Spark Connect) it is necessary to send certain stage properties coming from clients.
The list of properties to be sent is configurable, because there are a lot of properties and it would be expensive to send all of them with each stage.