### PR TITLE
millis_to_ts can work with SparkConnect

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -66,7 +66,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'com.joom.spark'
             artifactId = "spark-platform_$scalaVersion"
-            version = '0.4.6'
+            version = '0.4.7'
 
             from components.java
 

--- a/lib/src/main/scala/com/joom/spark/package.scala
+++ b/lib/src/main/scala/com/joom/spark/package.scala
@@ -4,14 +4,14 @@ import org.apache.spark.sql.{Column, DataFrame, Dataset, Encoders}
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
 import org.apache.spark.sql.catalyst.expressions.MillisToTs
 import org.apache.spark.sql.functions.{coalesce, col, concat, hash, lit, struct}
-import org.apache.spark.sql.types.{DataType, StructType}
+import org.apache.spark.sql.types.{DataType, StructType, TimestampType}
 
 import java.io.IOException
 
 package object spark {
 
   /** Convert long millisecond-since-epoch value into Timestamp type */
-  def millis_to_ts(c: Column) = new Column(MillisToTs(c.expr))
+  def millis_to_ts(c: Column): Column = (c / 1000).cast(TimestampType)
 
   object implicits {
 

--- a/lib/src/test/scala/com/joom/spark/MillisToTsSpec.scala
+++ b/lib/src/test/scala/com/joom/spark/MillisToTsSpec.scala
@@ -44,4 +44,17 @@ class MillisToTsSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     df2.count() shouldBe 0
   }
+
+  "millis_to_ts" should "preserve millis" in {
+    import spark.implicits._
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+
+    val df = Seq(1575891193535L)
+      .toDF("millis")
+      .withColumn("ts", millis_to_ts($"millis"))
+      .withColumn("tss", date_format($"ts", "yyyy-MM-dd HH:mm:ss.SSS"))
+
+    val row = df.collect()(0)
+    row.getString(2) shouldBe "2019-12-09 11:33:13.535"
+  }
 }


### PR DESCRIPTION
The current implementation of millis_to_ts crashes in SC mode with "java.lang.NoSuchMethodError: 'org.apache.spark.sql.catalyst.expressions.Expression org.apache.spark.sql.Column.expr()'".